### PR TITLE
Added 'Accept-Encoding': 'gzip' to the headers

### DIFF
--- a/qgenda/__init__.py
+++ b/qgenda/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.dev5'
+__version__ = '1.0.dev6'
 from . import api
 from . import cache
 from . import pipeline

--- a/qgenda/api/client.py
+++ b/qgenda/api/client.py
@@ -32,6 +32,7 @@ class QGendaClient:
             'user-agent': f'python-qgenda {self.username}',
             'Content-Type': 'application/x-www-form-urlencoded',
             'Transfer-Encoding': 'gzip',
+            'Accept-Encoding': 'gzip',
         }
         # list of methods that it is safe to include gzip headers for
         self.gzip_safe = []


### PR DESCRIPTION
Due to the OData v4 update of the Qgenda API, the header must be changed to include 'Accept-Encoding': 'gzip' to accept the full 100 days of data per API request.  Otherwise, only a maximum of 30 days can be returned.